### PR TITLE
Log stdout and stderr when a command is not running as expected.

### DIFF
--- a/testsuite/shell.go
+++ b/testsuite/shell.go
@@ -240,10 +240,10 @@ func ExecuteCommandSucceedsOrFails(command string, expectedResult string) error 
 	exitCode := shell.excbuf.String()
 
 	if expectedResult == "succeeds" && exitCode != "0" {
-		err = fmt.Errorf("command '%s', expected to succeed, exited with exit code: %s", command, exitCode)
+		err = fmt.Errorf("command '%s', expected to succeed, exited with exit code: %s\nCommand stdout: %s\nCommand stderr: %s", command, exitCode, shell.outbuf.String(), shell.errbuf.String())
 	}
 	if expectedResult == "fails" && exitCode == "0" {
-		err = fmt.Errorf("command '%s', expected to fail, exited with exit code: %s", command, exitCode)
+		err = fmt.Errorf("command '%s', expected to fail, exited with exit code: %s\nCommand stdout: %s\nCommand stderr: %s", command, exitCode, shell.outbuf.String(), shell.errbuf.String())
 	}
 
 	return err


### PR DESCRIPTION
The intent is to add more details when a command fails.

Example: https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com/view/gs/origin-ci-test/pr-logs/pull/code-ready_crc/1297/pull-ci-code-ready-crc-master-e2e-crc/1274295022597967872
```
  Scenario: Push local image to OpenShift image registry # features/story_registry.feature:24
    When executing "sudo podman push hello:test default-route-openshift-image-registry.apps-crc.testing/testproj-img/hello:test --tls-verify=false" succeeds # features/story_registry.feature:28
      Error: command 'sudo podman push hello:test default-route-openshift-image-registry.apps-crc.testing/testproj-img/hello:test --tls-verify=false', expected to succeed, exited with exit code: 125
```