### PR TITLE
Rename integration to e2e

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ go test
 
 ## How to use as package
 
-For a basic example of how the import is done, see the file `integration_test.go`.
+For a basic example of how the import is done, see the file `e2e_test.go`.

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package integration
+package e2e
 
 import (
 	"os"

--- a/testsuite/prepare.go
+++ b/testsuite/prepare.go
@@ -41,10 +41,10 @@ func ParseFlags() {
 	flag.Parse()
 }
 
-func PrepareForIntegrationTest() error {
+func PrepareForE2eTest() error {
 	var err error
 	if testDir == "" {
-		testDir, err = ioutil.TempDir("", "crc-integration-test-")
+		testDir, err = ioutil.TempDir("", "crc-e2e-test-")
 		if err != nil {
 			return fmt.Errorf("error creating temporary directory for test run: %v", err)
 		}
@@ -85,7 +85,7 @@ func PrepareForIntegrationTest() error {
 		return err
 	}
 
-	fmt.Printf("Running integration test in: %v\n", testRunDir)
+	fmt.Printf("Running e2e test in: %v\n", testRunDir)
 	fmt.Printf("Working directory set to: %v\n", testRunDir)
 
 	return nil

--- a/testsuite/shell.go
+++ b/testsuite/shell.go
@@ -119,7 +119,7 @@ func (shell *ShellInstance) ConfigureTypeOfShell(shellName string) {
 		shell.startArgument = []string{"-Command", "-"}
 		shell.checkExitCodeCmd = fmt.Sprintf(powershellExitCodeCheck, exitCodeIdentifier)
 	case "fish":
-		fmt.Println("Fish shell is currently not supported by integration tests. Default shell for the OS will be used.")
+		fmt.Println("Fish shell is currently not supported by e2e tests. Default shell for the OS will be used.")
 		fallthrough
 	default:
 		if shell.name != "" {

--- a/testsuite/testsuite.go
+++ b/testsuite/testsuite.go
@@ -139,7 +139,7 @@ func FeatureContext(s *godog.Suite) {
 		ConfigFileContainsKey)
 
 	s.BeforeSuite(func() {
-		err := PrepareForIntegrationTest()
+		err := PrepareForE2eTest()
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)

--- a/util/e2e_logger.go
+++ b/util/e2e_logger.go
@@ -32,18 +32,18 @@ const (
 )
 
 var (
-	IntegrationLog *log.Logger
-	logFile        *os.File
+	E2eLog  *log.Logger
+	logFile *os.File
 )
 
 func init() {
 	// Make sure there is a log, even before StartLog is called
-	IntegrationLog = log.New(ioutil.Discard, "", 0)
+	E2eLog = log.New(ioutil.Discard, "", 0)
 }
 
 func StartLog(logPath string) error {
 	t := time.Now()
-	logFileName := fmt.Sprintf("integration_%d-%d-%d_%02d-%02d-%02d.log", t.Year(), t.Month(),
+	logFileName := fmt.Sprintf("e2e_%d-%d-%d_%02d-%02d-%02d.log", t.Year(), t.Month(),
 		t.Day(), t.Hour(), t.Minute(), t.Second())
 	logPath = path.Join(logPath, logFileName)
 
@@ -53,7 +53,7 @@ func StartLog(logPath string) error {
 		return err
 	}
 
-	IntegrationLog = log.New(logFile, "", log.Ltime|log.Lmicroseconds)
+	E2eLog = log.New(logFile, "", log.Ltime|log.Lmicroseconds)
 	LogMessage("info", "Log Initiated")
 	fmt.Println("Log successfully started, logging into:", logPath)
 
@@ -67,7 +67,7 @@ func CloseLog() error {
 func LogMessage(messageInfo, message string) error {
 	messageInfo = formatMessageInfo(messageInfo)
 	message = formatMessage(message)
-	IntegrationLog.Print(messageInfo + message)
+	E2eLog.Print(messageInfo + message)
 
 	return nil
 }


### PR DESCRIPTION
This tool is intended to be used with high-level test cases. In anticipation of changes to tests in `code-ready/crc`, renaming integration to e2e in Clicumber will prevent confusion later.