### PR TITLE
Refactor shell code in testsuite

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,4 +4,4 @@ environment:
   GOPATH: c:\gopath
 stack: go 1.14
 test_script:
-  - go test
+  - go test --godog.tags=windows

--- a/features/testsuite.feature
+++ b/features/testsuite.feature
@@ -45,7 +45,7 @@ Quentin check whether their testsuite works properly.
       When creating directory "newdir" succeeds
        And creating file "newdir/newfile" succeeds
        And file from "https://google.com" is downloaded into location "newdir"
-      
+
    Scenario: File Content Checks
       When writing text "192.168.15.17" to file "newdir/newfile" succeeds
       Then content of file "newdir/newfile" should contain "168"

--- a/features/testsuite.feature
+++ b/features/testsuite.feature
@@ -1,6 +1,7 @@
 Feature: Testsuite test
 Quentin check whether their testsuite works properly.
 
+  @linux @darwin @windows
   Scenario: Contains
      When executing "go help" succeeds
      Then stdout should contain
@@ -8,6 +9,7 @@ Quentin check whether their testsuite works properly.
      Go is a tool for managing Go source code.
      """
 
+  @linux @darwin
   Scenario: Command which is not present
     When executing "foobar" fails
     Then exitcode should not equal "0"
@@ -16,44 +18,54 @@ Quentin check whether their testsuite works properly.
      command not found
      """
 
+  @linux @darwin @windows
   Scenario: Not Contains
      When executing "go help" succeeds
      Then stdout should not contain "Error"
 
+  @linux @darwin @windows
   Scenario: Equals
      When executing "go help" succeeds
      Then exitcode should equal "0"
 
+  @linux @darwin @windows
   Scenario: Not Equals
      When executing "go notexist" fails
      Then exitcode should not equal "0"
 
+  @linux @darwin @windows
   Scenario: Matches
      When executing "go version" succeeds
      Then stdout should match "go1\.\d+\.\d+"
 
+  @linux @darwin @windows
   Scenario: Not Matches
      When executing "go version" succeeds
      Then stdout should not match "Local \d\.\d OpenShift clusters"
 
+  @linux @darwin @windows
   Scenario: Is Empty
      When executing "go version" succeeds
      Then stderr should be empty
 
+  @linux @darwin @windows
   Scenario: Is Not Empty
      When executing "go version" succeeds
      Then stdout should not be empty
 
+  @linux @darwin
   Scenario: Scenario Variables
      When setting scenario variable "VAR" to the stdout from executing "go version"
       And executing "echo $(VAR)" succeeds
      Then stdout should contain "go version"
 
+  @linux @darwin @windows
    Scenario: Create Directory and Files
       When creating directory "newdir" succeeds
        And creating file "newdir/newfile" succeeds
        And file from "https://google.com" is downloaded into location "newdir"
 
+  @linux @darwin @windows
    Scenario: File Content Checks
       When writing text "192.168.15.17" to file "newdir/newfile" succeeds
       Then content of file "newdir/newfile" should contain "168"
@@ -64,16 +76,19 @@ Quentin check whether their testsuite works properly.
        And content of file "newdir/newfile" should not match "192\.168\.\s+\.\d+"
        And content of file "newdir/newfile" is valid "IP"
 
+  @linux @darwin @windows
    Scenario: Delete file
       When deleting file "newdir/newfile" succeeds
       Then file "newdir/newfile" should not exist
 
+  @linux @darwin @windows
    Scenario: Delete directory
       When deleting directory "newdir" succeeds
       Then directory "newdir" should not exist
 
    # Config 
 
+  @linux @darwin @windows
    Scenario Outline: Verify key exists in JSON/YAML config file
       Given file "<filename>" exists
       When  "<format>" config file "<filename>" contains key "<property>"
@@ -92,6 +107,7 @@ Quentin check whether their testsuite works properly.
       | YAML   | ../../testdata/testconfig.yml  | version           | nonversion  | 2          | two      |
       | YAML   | ../../testdata/testconfig.yml  | version           | nonversion  | \d+        | two      |
 
+  @linux @darwin @windows
    Scenario: Verify that key matching value exists in JSON config file
       When file "../../testdata/testconfig.json" exists
       # JSON package uses map[string]interface{} and []interface{} values to store various JSON objects

--- a/features/testsuite.feature
+++ b/features/testsuite.feature
@@ -18,6 +18,15 @@ Quentin check whether their testsuite works properly.
      command not found
      """
 
+  @windows
+  Scenario: Command which is not present
+    When executing "foobar" fails
+    Then exitcode should not equal "0"
+    Then stderr should contain
+     """
+     'foobar' is not recognized
+     """
+
   @linux @darwin @windows
   Scenario: Not Contains
      When executing "go help" succeeds
@@ -58,6 +67,12 @@ Quentin check whether their testsuite works properly.
      When setting scenario variable "VAR" to the stdout from executing "go version"
       And executing "echo $(VAR)" succeeds
      Then stdout should contain "go version"
+
+  @windows
+  Scenario: Scenario Variables
+    When setting scenario variable "VAR" to the stdout from executing "go version"
+    And executing "echo $(VAR)" succeeds
+    Then stdout should contain "version"
 
   @linux @darwin @windows
    Scenario: Create Directory and Files

--- a/features/testsuite.feature
+++ b/features/testsuite.feature
@@ -8,6 +8,14 @@ Quentin check whether their testsuite works properly.
      Go is a tool for managing Go source code.
      """
 
+  Scenario: Command which is not present
+    When executing "foobar" fails
+    Then exitcode should not equal "0"
+    Then stderr should contain
+     """
+     command not found
+     """
+
   Scenario: Not Contains
      When executing "go help" succeeds
      Then stdout should not contain "Error"

--- a/integration_test.go
+++ b/integration_test.go
@@ -21,8 +21,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cucumber/godog"
 	"github.com/code-ready/clicumber/testsuite"
+	"github.com/cucumber/godog"
 )
 
 func TestMain(m *testing.M) {

--- a/testsuite/shell.go
+++ b/testsuite/shell.go
@@ -17,53 +17,31 @@ limitations under the License.
 package testsuite
 
 import (
-	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
-	"io"
+	"os"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
-	"github.com/cucumber/messages-go/v10"
 	"github.com/code-ready/clicumber/util"
-)
-
-const (
-	exitCodeIdentifier = "exitCodeOfLastCommandInShell="
-
-	bashExitCodeCheck       = "echo %v$?"
-	fishExitCodeCheck       = "echo %v$status"
-	tcshExitCodeCheck       = "echo %v$?"
-	zshExitCodeCheck        = "echo %v$?"
-	cmdExitCodeCheck        = "echo %v%%errorlevel%%"
-	powershellExitCodeCheck = "echo %v$lastexitcode"
+	"github.com/cucumber/messages-go/v10"
 )
 
 var (
-	shell ShellInstance
+	shell = &ShellInstance{}
 )
 
 type ShellInstance struct {
-	startArgument    []string
-	name             string
-	checkExitCodeCmd string
+	startArgument []string
+	name          string
+	exitCode      int
 
-	instance *exec.Cmd
-	outbuf   bytes.Buffer
-	errbuf   bytes.Buffer
-	excbuf   bytes.Buffer
-
-	outPipe io.ReadCloser
-	errPipe io.ReadCloser
-	inPipe  io.WriteCloser
-
-	outScanner *bufio.Scanner
-	errScanner *bufio.Scanner
-
-	exitCodeChannel chan string
+	outbuf bytes.Buffer
+	errbuf bytes.Buffer
 }
 
 func (shell *ShellInstance) GetLastCmdOutput(stdType string) string {
@@ -74,7 +52,7 @@ func (shell *ShellInstance) GetLastCmdOutput(stdType string) string {
 	case "stderr":
 		returnValue = shell.errbuf.String()
 	case "exitcode":
-		returnValue = shell.excbuf.String()
+		returnValue = strconv.Itoa(shell.exitCode)
 	default:
 		fmt.Printf("Field '%s' of shell's output is not supported. Only 'stdout', 'stderr' and 'exitcode' are supported.", stdType)
 	}
@@ -84,40 +62,19 @@ func (shell *ShellInstance) GetLastCmdOutput(stdType string) string {
 	return returnValue
 }
 
-func (shell *ShellInstance) ScanPipe(scanner *bufio.Scanner, buffer *bytes.Buffer, stdType string) {
-	for scanner.Scan() {
-		str := scanner.Text()
-		util.LogMessage(stdType, str)
-
-		if strings.Contains(str, exitCodeIdentifier) && !strings.Contains(str, shell.checkExitCodeCmd) {
-			exitCode := strings.Split(str, "=")[1]
-			shell.exitCodeChannel <- exitCode
-		} else {
-			buffer.WriteString(str + "\n")
-		}
-	}
-
-	return
-}
-
 func (shell *ShellInstance) ConfigureTypeOfShell(shellName string) {
 	switch shellName {
 	case "bash":
 		shell.name = shellName
-		shell.checkExitCodeCmd = fmt.Sprintf(bashExitCodeCheck, exitCodeIdentifier)
 	case "tcsh":
 		shell.name = shellName
-		shell.checkExitCodeCmd = fmt.Sprintf(tcshExitCodeCheck, exitCodeIdentifier)
 	case "zsh":
 		shell.name = shellName
-		shell.checkExitCodeCmd = fmt.Sprintf(zshExitCodeCheck, exitCodeIdentifier)
 	case "cmd":
 		shell.name = shellName
-		shell.checkExitCodeCmd = fmt.Sprintf(cmdExitCodeCheck, exitCodeIdentifier)
 	case "powershell":
 		shell.name = shellName
 		shell.startArgument = []string{"-Command", "-"}
-		shell.checkExitCodeCmd = fmt.Sprintf(powershellExitCodeCheck, exitCodeIdentifier)
 	case "fish":
 		fmt.Println("Fish shell is currently not supported by integration tests. Default shell for the OS will be used.")
 		fallthrough
@@ -128,103 +85,57 @@ func (shell *ShellInstance) ConfigureTypeOfShell(shellName string) {
 		switch runtime.GOOS {
 		case "darwin", "linux":
 			shell.name = "bash"
-			shell.checkExitCodeCmd = fmt.Sprintf(bashExitCodeCheck, exitCodeIdentifier)
 		case "windows":
 			shell.name = "powershell"
 			shell.startArgument = []string{"-Command", "-"}
-			shell.checkExitCodeCmd = fmt.Sprintf(powershellExitCodeCheck, exitCodeIdentifier)
 		}
 	}
-
 	return
 }
 
-func StartHostShellInstance(shellName string) error {
-	return shell.Start(shellName)
+func SetUpHostShellInstance(shellName string) error {
+	return shell.Setup(shellName)
 }
 
-func (shell *ShellInstance) Start(shellName string) error {
-	var err error
-
+func (shell *ShellInstance) Setup(shellName string) error {
 	if shell.name == "" {
 		shell.ConfigureTypeOfShell(shellName)
 	}
-	shell.exitCodeChannel = make(chan string)
 
-	shell.instance = exec.Command(shell.name, shell.startArgument...)
-
-	shell.outPipe, err = shell.instance.StdoutPipe()
-	if err != nil {
-		return err
-	}
-
-	shell.errPipe, err = shell.instance.StderrPipe()
-	if err != nil {
-		return err
-	}
-
-	shell.inPipe, err = shell.instance.StdinPipe()
-	if err != nil {
-		return err
-	}
-
-	shell.outScanner = bufio.NewScanner(shell.outPipe)
-	shell.errScanner = bufio.NewScanner(shell.errPipe)
-
-	go shell.ScanPipe(shell.outScanner, &shell.outbuf, "stdout")
-	go shell.ScanPipe(shell.errScanner, &shell.errbuf, "stderr")
-
-	err = shell.instance.Start()
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("The %v instance has been started and will be used for testing.\n", shell.name)
-	return err
-}
-
-func CloseHostShellInstance() error {
-	return shell.Close()
-}
-
-func (shell *ShellInstance) Close() error {
-	closingCmd := "exit\n"
-	io.WriteString(shell.inPipe, closingCmd)
-	err := shell.instance.Wait()
-	if err != nil {
-		fmt.Println("error closing shell instance:", err)
-	}
-
-	shell.instance = nil
-
-	return err
+	fmt.Printf("The %v shell will be used for testing.\n", shell.name)
+	return nil
 }
 
 func ExecuteCommand(command string) error {
-	if shell.instance == nil {
-		return errors.New("shell instance is not started")
+	if shell.name == "" {
+		return errors.New("shell instance is not initialized")
 	}
-
+	var (
+		exitError *exec.ExitError
+		pathError *os.PathError
+	)
+	shell.exitCode = 0
 	shell.outbuf.Reset()
 	shell.errbuf.Reset()
-	shell.excbuf.Reset()
 
 	util.LogMessage(shell.name, command)
 
-	_, err := io.WriteString(shell.inPipe, command+"\n")
-	if err != nil {
-		return err
+	cmd := exec.Command(shell.name, shell.startArgument...)
+	cmd.Stderr = &shell.errbuf
+	cmd.Stdout = &shell.outbuf
+	cmd.Stdin = strings.NewReader(command + "\n")
+
+	if err := cmd.Run(); err != nil {
+		switch {
+		case errors.As(err, &exitError):
+			shell.exitCode = exitError.ExitCode()
+		case errors.As(err, &pathError):
+			return fmt.Errorf("os.PathError: %w", err)
+		default:
+			return fmt.Errorf("something went wrong with %s command: %w", command, err)
+		}
 	}
-
-	_, err = shell.inPipe.Write([]byte(shell.checkExitCodeCmd + "\n"))
-	if err != nil {
-		return err
-	}
-
-	exitCode := <-shell.exitCodeChannel
-	shell.excbuf.WriteString(exitCode)
-
-	return err
+	return nil
 }
 
 func ExecuteCommandSucceedsOrFails(command string, expectedResult string) error {
@@ -233,7 +144,7 @@ func ExecuteCommandSucceedsOrFails(command string, expectedResult string) error 
 		return err
 	}
 
-	exitCode := shell.excbuf.String()
+	exitCode := strconv.Itoa(shell.exitCode)
 
 	if expectedResult == "succeeds" && exitCode != "0" {
 		err = fmt.Errorf("command '%s', expected to succeed, exited with exit code: %s\nCommand stdout: %s\nCommand stderr: %s", command, exitCode, shell.outbuf.String(), shell.errbuf.String())
@@ -254,7 +165,7 @@ func ExecuteCommandWithRetry(retryCount int, retryTime string, command string, c
 
 	for i := 0; i < retryCount; i++ {
 		err := ExecuteCommand(command)
-		exitCode, stdout := shell.excbuf.String(), shell.outbuf.String()
+		exitCode, stdout := strconv.Itoa(shell.exitCode), shell.outbuf.String()
 		if strings.Contains(containsOrNot, " not ") {
 			if err == nil && exitCode == "0" && !strings.Contains(stdout, expected) {
 				return nil
@@ -275,9 +186,7 @@ func ExecuteStdoutLineByLine() error {
 	stdout := shell.GetLastCmdOutput("stdout")
 	commandArray := strings.Split(stdout, "\n")
 	for index := range commandArray {
-		if !strings.Contains(commandArray[index], exitCodeIdentifier) {
-			err = ExecuteCommand(commandArray[index])
-		}
+		err = ExecuteCommand(commandArray[index])
 	}
 
 	return err

--- a/testsuite/testsuite.go
+++ b/testsuite/testsuite.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/code-ready/clicumber/util"
 	"github.com/cucumber/godog"
 	"github.com/cucumber/messages-go/v10"
-	"github.com/code-ready/clicumber/util"
 )
 
 var (
@@ -148,7 +148,7 @@ func FeatureContext(s *godog.Suite) {
 
 	s.BeforeFeature(func(this *messages.GherkinDocument) {
 		util.LogMessage("info", fmt.Sprintf("----- Feature: %s -----", this.String()))
-		StartHostShellInstance(testWithShell)
+		SetUpHostShellInstance(testWithShell)
 		util.ClearScenarioVariables()
 		err := CleanTestRunDir()
 		if err != nil {
@@ -171,7 +171,6 @@ func FeatureContext(s *godog.Suite) {
 
 	s.AfterFeature(func(*messages.GherkinDocument) {
 		util.LogMessage("info", "----- Cleaning after feature -----")
-		CloseHostShellInstance()
 	})
 
 	s.AfterSuite(func() {


### PR DESCRIPTION
- Create shell instance only for the command execute
- Remove channel dependency to get the exitCode
- Use go capability to get exitcode for a process instead running a custom command
- Refactor shell struct configuration