### PR TITLE
circleci: Sync xcode and golang versions with crc's

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 
 ## Machine specific variable
 jobs:
-  run-feature-mac:
+  run-features-mac:
     macos:
       xcode: "10.0.0"
     environment:
@@ -31,7 +31,7 @@ jobs:
     - run:
         name: Run test
         command: go test -race
-      
+
 workflows:
   version: 2
   build_and_test:
@@ -46,4 +46,4 @@ workflows:
               only:
                 - master
     jobs:
-      - run-features
+      - run-features-mac

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,9 +5,9 @@ version: 2
 jobs:
   run-features-mac:
     macos:
-      xcode: "10.0.0"
+      xcode: "12.5.1"
     environment:
-      GOVERSION: "1.14.13"
+      GOVERSION: "1.15.13"
     steps:
     - checkout
     - run:


### PR DESCRIPTION
crc uses golang 1.15.13 and xcode 12.5.1 in its circleci configuration.
The xcode image currently used by clicumber will be dropped in September
2021
https://circleci.com/docs/2.0/xcode-policy/
https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions